### PR TITLE
Refine chat error handling and restrict preset test command

### DIFF
--- a/amrita/plugins/chat/handlers/preset_test.py
+++ b/amrita/plugins/chat/handlers/preset_test.py
@@ -5,6 +5,7 @@ from nonebot.adapters.onebot.v11 import Bot, Message, MessageEvent, MessageSegme
 from nonebot.matcher import Matcher
 from nonebot.params import CommandArg
 
+from amrita.plugins.chat.check_rule import is_bot_admin
 from amrita.plugins.chat.config import config_manager
 from amrita.plugins.chat.utils.libchat import PresetReport, test_presets
 from amrita.utils.send import send_forward_msg
@@ -15,6 +16,8 @@ TEST_LOCK = Lock()
 async def t_preset(
     event: MessageEvent, matcher: Matcher, bot: Bot, args: Message = CommandArg()
 ):
+    if not await is_bot_admin(event):
+        await matcher.finish("仅允许Bot管理员使用此命令。")
     if TEST_LOCK.locked():
         await matcher.finish("当前仍然有1个测试任务正在执行，请稍后再试。")
     async with TEST_LOCK:

--- a/amrita/plugins/chat/utils/libchat.py
+++ b/amrita/plugins/chat/utils/libchat.py
@@ -78,7 +78,7 @@ async def test_presets() -> typing.AsyncGenerator[PresetReport, None]:
     for preset in presets:
         logger.debug(f"正在测试预设：{preset.name}...")
         adapter = AdapterManager().safe_get_adapter(preset.protocol)
-        if not adapter:
+        if adapter is None:
             logger.warning(f"未定义的协议适配器：{preset.protocol}")
             yield PresetReport(
                 preset_name=preset.name,
@@ -91,8 +91,7 @@ async def test_presets() -> typing.AsyncGenerator[PresetReport, None]:
                 message=f"未定义的协议适配器: {preset.protocol}",
                 time_used=0,
             )
-
-        assert adapter
+            return
         try:
             time_start = time.time()
             logger.debug(f"正在调用预设：{preset.name}...")
@@ -245,7 +244,7 @@ async def tools_caller(
             err = e
             continue
     else:
-        raise RuntimeError("所有适配器调用失败") from err
+        raise err or RuntimeError("所有适配器调用失败")
 
 
 async def get_chat(
@@ -255,6 +254,8 @@ async def get_chat(
     # 检查消息中是否包含非文本内容（如图片等）
     has_multimodal_content = False
     for msg in messages:
+        if isinstance(msg.content, str):
+            continue
         for content in msg.content:
             if not isinstance(content, TextContent):
                 has_multimodal_content = True
@@ -324,7 +325,7 @@ async def get_chat(
             continue
     else:
         logger.warning("所有适配器调用失败")
-        raise Exception("所有适配器调用失败") from err
+        raise err or Exception("所有适配器调用失败")
 
 
 class OpenAIAdapter(ModelAdapter):

--- a/amrita/plugins/chat/utils/libchat.py
+++ b/amrita/plugins/chat/utils/libchat.py
@@ -91,7 +91,7 @@ async def test_presets() -> typing.AsyncGenerator[PresetReport, None]:
                 message=f"未定义的协议适配器: {preset.protocol}",
                 time_used=0,
             )
-            return
+            continue
         try:
             time_start = time.time()
             logger.debug(f"正在调用预设：{preset.name}...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.3.0"
+version = "0.3.1"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
fix #45

## Sourcery 总结

通过优化适配器检查和错误处理、防止字符串内容被错误归类、限制预设测试访问权限给机器人管理员，以及提升项目版本，来修复聊天功能中的错误。

错误修复：
- 在 `test_presets` 中处理未定义的适配器，避免断言失败
- 防止 `get_chat` 将字符串消息视为多模态内容
- 当 `tools_caller` 和 `get_chat` 中所有适配器都失败时，传播原始异常

功能增强：
- 对适配器是否存在进行显式 `None` 检查
- 将预设测试命令限制给机器人管理员使用

构建：
- 将项目版本提升至 0.3.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix chat function errors by refining adapter checks and error handling, preventing string content misclassification, restricting preset test access to bot admins, and bumping project version.

Bug Fixes:
- Handle undefined adapters in test_presets without assertion failure
- Prevent treating string messages as multimodal content in get_chat
- Propagate original exceptions when all adapters fail in tools_caller and get_chat

Enhancements:
- Use explicit None check for adapter presence
- Restrict preset testing command to bot administrators

Build:
- Bump project version to 0.3.1

</details>