### PR TITLE
修复ToolsCaller

### DIFF
--- a/amrita/plugins/chat/utils/libchat.py
+++ b/amrita/plugins/chat/utils/libchat.py
@@ -199,6 +199,8 @@ async def tools_caller(
 ):
     has_multimodal_content = False
     for msg in messages:
+        if isinstance(msg.content, str):
+            continue
         for content in msg.content:
             if not isinstance(content, TextContent):
                 has_multimodal_content = True

--- a/amrita/plugins/chat/utils/libchat.py
+++ b/amrita/plugins/chat/utils/libchat.py
@@ -43,10 +43,11 @@ from .protocol import (
 )
 
 TEST_MSG_PROMPT: Message[list[TextContent]] = Message(
-    role="system", content=[TextContent(text="You are a helpful assistant.")]
+    role="system",
+    content=[TextContent(text="You are a helpful assistant.", type="text")],
 )
 TEST_MSG_USER: Message[list[TextContent]] = Message(
-    role="user", content=[TextContent(text="你好，请简要介绍你自己。")]
+    role="user", content=[TextContent(text="你好，请简要介绍你自己。", type="text")]
 )
 
 TEST_MSG_LIST = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.3.1"
+version = "0.3.1.1"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Sourcery 摘要

调整 tools_caller 以忽略带有字符串内容边界的消息，并更新项目版本

Bug 修复:
- 在 tools_caller 中跳过字符串内容消息，以防止对消息内容进行错误的迭代

构建:
- 将项目版本提升至 0.3.1.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tools_caller to ignore messages with string content boundaries and update the project version

Bug Fixes:
- Skip string content messages in tools_caller to prevent erroneous iteration over message content

Build:
- Bump project version to 0.3.1.1

</details>