### PR TITLE
添加数据结构校验

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.3.2"
+version = "0.3.3"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Sourcery 摘要

通过在整个聊天工具和处理程序中将原始字典输入转换为 `Message` 或 `ToolResult` 实例，为消息引入模式验证，并提升项目版本。

增强功能：
- 在 `libchat` 中添加 `_validate_msg_list`，用于将传入的消息字典转换为 `Message` 或 `ToolResult` 对象并进行验证
- 更新 `_determine_presets` 和聊天处理程序，使用 `Message.model_validate` 处理消息和训练配置
- 重构 `prepare_send_messages`，使其操作经过验证的 `Message` 对象，并确保内容是字符串

构建：
- 将版本提升至 0.3.3

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce schema validation for messages by converting raw dict inputs into Message or ToolResult instances throughout the chat utilities and handlers, and increment the project version.

Enhancements:
- Add `_validate_msg_list` in libchat to convert and validate incoming message dicts into Message or ToolResult objects
- Update `_determine_presets` and chat handlers to use `Message.model_validate` for message and train configurations
- Refactor `prepare_send_messages` to operate on validated Message objects and ensure content is a string

Build:
- Bump version to 0.3.3

</details>