### PR TITLE
修复CLI错误

### DIFF
--- a/amrita/cli.py
+++ b/amrita/cli.py
@@ -44,8 +44,8 @@ def get_package_metadata(package_name: str) -> dict[str, Any] | None:
 
 def should_update() -> tuple[bool, str]:
     if metadata := get_package_metadata("amrita"):
-        if metadata["releases"] != {} and max(
-            list(metadata["releases"].keys()), key=version.parse
+        if metadata["releases"] != {} and version.parse(
+            max(list(metadata["releases"].keys()), key=version.parse)
         ) > version.parse(get_amrita_version()):
             latest_version = list(metadata["releases"].keys())[-1]
             return True, latest_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.4.0"
+version = "0.4.0.1"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Sourcery 总结

修复 CLI 更新检查器中的版本比较并提升项目版本

错误修复：
- 在 `should_update` 中比较版本之前，将 `version.parse` 应用于最新发布版本字符串，以确保正确的比较

杂项任务：
- 将项目版本从 0.4.0 提升到 0.4.0.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix version comparison in CLI update checker and bump project version

Bug Fixes:
- Apply version.parse to the latest release string before comparing versions in should_update to ensure correct comparison

Chores:
- Bump project version from 0.4.0 to 0.4.0.1

</details>