### PR TITLE
添加多个reasoing模式

### DIFF
--- a/amrita/plugins/chat/builtin_hook.py
+++ b/amrita/plugins/chat/builtin_hook.py
@@ -144,10 +144,14 @@ async def agent_core(event: BeforeChatEvent) -> None:
         original_msg: str = "",
     ):
         logger.debug(f"开始第{call_count + 1}轮工具调用，当前消息数: {len(msg_list)}")
-        if (
-            call_count == 0
-            and config_manager.config.llm_config.tools.agent_mode_enable
-            and config_manager.config.llm_config.tools.agent_thought_mode == "reasoning"
+        if config_manager.config.llm_config.tools.agent_mode_enable and (
+            (
+                call_count == 0
+                and config_manager.config.llm_config.tools.agent_thought_mode
+                == "reasoning"
+            )
+            or config_manager.config.llm_config.tools.agent_thought_mode
+            == "reasoning-required"
         ):
             await append_reasoning_msg(msg_list, original_msg)
 
@@ -293,7 +297,7 @@ async def agent_core(event: BeforeChatEvent) -> None:
     tools: list[dict[str, Any]] = []
     if config.llm_config.tools.agent_mode_enable:
         tools.append(STOP_TOOL.model_dump())
-        if config.llm_config.tools.agent_thought_mode == "reasoning":
+        if config.llm_config.tools.agent_thought_mode.startswith("reasoning"):
             tools.append(REASONING_TOOL.model_dump(exclude_none=True))
     tools.extend(ToolsManager().tools_meta_dict(exclude_none=True).values())
     logger.debug(f"工具列表：{tools}")

--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -105,10 +105,14 @@ class ToolsConfig(BaseModel):
     require_tools: bool = False
     agent_mode_enable: bool = False  # 使用实验性的智能体模式
     agent_tool_call_limit: int = 10  # 智能体模式下的工具调用限制
-    agent_thought_mode: Literal["reasoning", "chat"] = (
+    agent_thought_mode: Literal[
+        "reasoning", "chat", "reasoning-required", "reasoning-optional"
+    ] = (
         "chat"  # 使用实验性的智能体模式下的思考模式,
-        # reasoning模式会先执行思考过程，然后执行任务;
-        # chat模式会直接执行任务。
+        # reasoning 模式会先执行思考过程，然后执行任务;
+        # reasoning-required 要求每次Tool Calling都执行任务分析。
+        # reasoning-optional 不要求reasoning，但是允许reasoning
+        # chat 模式会直接执行任务。
     )
     agent_mcp_client_enable: bool = False
     agent_mcp_server_scripts: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.4.1"
+version = "0.4.2"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -17,11 +17,11 @@ dependencies = [
     "requests>=2.0", # See https://github.com/twindb/backup/pull/465
     "python-multipart>=0.0.20",
     "aiofiles>=24.1.0",
+    "packaging>=25.0",
 ]
 
 [project.optional-dependencies]
 full = [
-    "packaging>=25.0",
     "aiohttp>=3.13.2",
     "pillow>=12.0.0",
     "fastmcp>=2.13.0.2",


### PR DESCRIPTION
## Sourcery 总结

新增两种用于推理的代理思维模式 (reasoning-required 和 reasoning-optional)，更新工具调用逻辑以遵循这些模式，并为下一次发布做准备。

新功能：
- 引入 "reasoning-required" 和 "reasoning-optional" 模式，用于代理思维过程配置
- 当 agent_thought_mode 以 "reasoning" 开头时，启用推理工具调用

改进：
- 重构 run_tools 逻辑，使用 startswith 匹配来处理多种推理模式

构建：
- 将项目版本提升至 0.4.2

杂项：
- 将 packaging 依赖项移至核心依赖项中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add two new agent thought modes for reasoning (reasoning-required and reasoning-optional), update tool invocation logic to respect these modes, and prepare the next release.

New Features:
- Introduce "reasoning-required" and "reasoning-optional" modes for agent thought process configuration
- Enable reasoning tool invocation when agent_thought_mode starts with "reasoning"

Enhancements:
- Refactor run_tools logic to handle multiple reasoning modes using startswith matching

Build:
- Bump project version to 0.4.2

Chores:
- Move packaging dependency into core dependencies

</details>