### PR TITLE
修复CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.4.4"
+version = "0.4.5"
 description = "A powerful bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

修复 CLI 项目初始化配置并更新打包元数据。

Bug Fixes:
- 更正项目初始化逻辑，将 `requires-python` 约束直接写入生成的 `pyproject.toml`，而不是依赖内部模型字段。
- 调整 CLI 配置中的 Ruff 工具配置为普通字典结构，以兼容生成的配置格式。

Enhancements:
- 在生成的 `pyproject.toml` 中填充 setuptools 的包发现设置，使 `plugins` 和 `src/plugins` 下的插件包能够被包含。
- 将核心包版本提升到 `0.4.5`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix CLI project initialization configuration and update packaging metadata.

Bug Fixes:
- Correct project initialization to write the requires-python constraint directly into the generated pyproject.toml instead of relying on the internal model field.
- Adjust the Ruff tool configuration in the CLI config to a plain dictionary structure compatible with the generated configuration format.

Enhancements:
- Populate setuptools package discovery settings in generated pyproject.toml so plugin packages under plugins and src/plugins are included.
- Bump the core package version to 0.4.5.

</details>