### PR TITLE
Track event permissions and invalidate user/group caches post-event

### DIFF
--- a/amrita/plugins/perm/API/rules.py
+++ b/amrita/plugins/perm/API/rules.py
@@ -39,7 +39,7 @@ _event_to_key_mapping: dict[str, tuple[str, str]]
 
 
 @event_postprocessor
-async def _(event: Event):  # noqa: RUF029
+async def _(event: Event):
     event_id = event.get_session_id()
     if data := _event_to_key_mapping.get(event_id):
         uni_id, permission = data


### PR DESCRIPTION
【VIBE】

- 添加事件ID到权限节点的映射机制
- 实现事件后处理钩子清理权限缓存
- 支持用户权限和群组权限缓存的精确清理
- 考虑group_only为true/false两种情况

解决NoneBot每次事件处理后权限缓存不及时清理导致的权限检查滞后问题。

## Summary by Sourcery

按事件追踪已检查的权限，并在每个事件处理结束后清理对应的权限缓存条目，以避免基于 LRU 的权限结果变陈旧。

New Features:
- 引入事件到权限的映射，用于记录在处理特定事件时检查了哪些用户和群组权限。
- 添加统一的权限缓存清理机制，在消息、通知和请求事件结束后触发。

Bug Fixes:
- 确保在对应事件处理完成后，用户和群组的 LRU 权限缓存会被失效，从而避免在 `group_only=true` 和 `group_only=false` 两种场景下出现权限更新延迟。

Enhancements:
- 优化权限检查逻辑，为每次检查关联一个按事件划分的标识，从而可以对受影响的用户和群组执行精确的缓存失效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track permissions checked per event and clear corresponding cached permission entries after each event to avoid stale LRU-based permission results.

New Features:
- Introduce an event-to-permission mapping to record which user and group permissions are checked during handling of a specific event.
- Add a unified permission cache cleanup mechanism that is triggered after message, notice, and request events.

Bug Fixes:
- Ensure user and group permission LRU caches are invalidated after the corresponding event is processed, preventing delayed permission updates for both group_only=true and group_only=false cases.

Enhancements:
- Refine permission checking to associate each check with a per-event identifier, enabling precise cache invalidation for affected users and groups.

</details>

新功能：
- 引入事件到权限的映射，用于记录在处理特定事件时检查了哪些用户和用户组权限。
- 添加一个事件后的清理钩子，根据已处理的事件清除相关的权限缓存条目。

错误修复：
- 修复由于基于 LRU 的用户和用户组权限缓存未在事件之后失效而导致的权限检查延迟问题，涵盖 `group_only=true` 和 `group_only=false` 两种情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

按事件追踪已检查的权限，并在每个事件处理结束后清理对应的权限缓存条目，以避免基于 LRU 的权限结果变陈旧。

New Features:
- 引入事件到权限的映射，用于记录在处理特定事件时检查了哪些用户和群组权限。
- 添加统一的权限缓存清理机制，在消息、通知和请求事件结束后触发。

Bug Fixes:
- 确保在对应事件处理完成后，用户和群组的 LRU 权限缓存会被失效，从而避免在 `group_only=true` 和 `group_only=false` 两种场景下出现权限更新延迟。

Enhancements:
- 优化权限检查逻辑，为每次检查关联一个按事件划分的标识，从而可以对受影响的用户和群组执行精确的缓存失效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track permissions checked per event and clear corresponding cached permission entries after each event to avoid stale LRU-based permission results.

New Features:
- Introduce an event-to-permission mapping to record which user and group permissions are checked during handling of a specific event.
- Add a unified permission cache cleanup mechanism that is triggered after message, notice, and request events.

Bug Fixes:
- Ensure user and group permission LRU caches are invalidated after the corresponding event is processed, preventing delayed permission updates for both group_only=true and group_only=false cases.

Enhancements:
- Refine permission checking to associate each check with a per-event identifier, enabling precise cache invalidation for affected users and groups.

</details>

</details>