### PR TITLE
修复本地插件加载

### DIFF
--- a/amrita/cmds/main.py
+++ b/amrita/cmds/main.py
@@ -20,7 +20,7 @@ import toml
 import tomli_w
 from pydantic import BaseModel, Field
 
-from amrita.cmds.wrapper import cwd_to_module, require_init
+from amrita.cmds.wrapper import require_init
 
 from ..cli import (
     IS_IN_VENV,
@@ -346,7 +346,6 @@ def entry():
         )
 
 
-@cwd_to_module
 @cli.command()
 @click.option("--run", "-r", is_flag=True, help="运行项目而不安装依赖。")
 def run(run: bool):
@@ -547,7 +546,6 @@ def nb(nb_args):
     __main__.main(nb_args)
 
 
-@cwd_to_module
 @cli.command()
 @click.option("--ignore-venv", "-i", is_flag=True, help="忽略Venv环境")
 def test(ignore_venv: bool):

--- a/amrita/cmds/wrapper.py
+++ b/amrita/cmds/wrapper.py
@@ -8,15 +8,6 @@ import amrita
 from amrita.cli import check_optional_dependency, error
 
 
-def cwd_to_module(func: Callable):
-    def wrapper(*args, **kwargs):
-        if "." not in sys.path:
-            sys.path.insert(0, ".")
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def require_full_depencies(func: Callable):
     def wrapper(*args, **kwargs):
         if not check_optional_dependency(quiet=True):

--- a/amrita/utils/plugins.py
+++ b/amrita/utils/plugins.py
@@ -18,7 +18,10 @@ def apply_alias():
 
 
 def load_plugins():
+    if "." not in sys.path:
+        sys.path.insert(0, ".")
     nonebot.load_from_toml("pyproject.toml")
+
     for name in (Path(__file__).parent.parent / "plugins").iterdir():
         # 修改说明：为了Amrita项目的完整性，内置插件不会再允许被禁用。
         nonebot.logger.debug(f"Require built-in plugin {name.name}...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.5.2.1"
+version = "0.5.2.2"
 description = "A powerful AI bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary by Sourcery

通过调整当前工作目录添加到模块搜索路径的方式，并将这一逻辑集中到插件加载器中，确保本地插件可以被正确加载。

Bug Fixes:
- 修复本地插件加载问题：在插件加载流程中将当前工作目录添加到 `sys.path`，而不是通过 CLI 装饰器来添加。

Enhancements:
- 移除现在已不再需要的、与模块路径处理相关的 CLI 包装装饰器。
- 将项目版本号从 0.5.2.1 提升到 0.5.2.2 以反映此次修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure local plugins can be properly loaded by adjusting how the current working directory is added to the module search path and centralizing this logic in the plugin loader.

Bug Fixes:
- Fix local plugin loading by adding the current working directory to sys.path within the plugin loading routine instead of via CLI decorators.

Enhancements:
- Remove now-unnecessary CLI wrapper decorators related to module path handling.
- Bump project version from 0.5.2.1 to 0.5.2.2 to reflect the fix.

</details>