### PR TITLE
fallback: 恢复到原始check_rule方式

### DIFF
--- a/amrita/plugins/chat/check_rule.py
+++ b/amrita/plugins/chat/check_rule.py
@@ -24,7 +24,7 @@ from .utils.functions import (
     synthesize_message,
 )
 from .utils.memory import get_memory_data
-from .utils.models import Message, get_or_create_group_config
+from .utils.models import Message, get_or_create_data
 
 nb_config = get_driver().config
 
@@ -56,7 +56,9 @@ async def is_bot_enabled(event: Event) -> bool:
             return False
     if getattr(event, "group_id", None) is not None:
         async with get_session() as session:
-            data = await get_or_create_group_config(session, getattr(event, "group_id"))
+            data, _ = await get_or_create_data(
+                session=session, ins_id=getattr(event, "group_id"), is_group=True
+            )
             return data.enable
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.7.1"
+version = "0.7.2"
 description = "A powerful AI bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary by Sourcery

将聊天规则检查切换为使用通用的数据检索辅助函数，并提升包版本。

增强：
- 在机器人启用检查中，使用共享的 `get_or_create_data` 辅助函数来查找群组配置。

构建：
- 将项目版本从 0.7.1 升级到 0.7.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch chat rule checking to use the generic data retrieval helper and bump the package version.

Enhancements:
- Use the shared get_or_create_data helper for group configuration lookup in bot enablement checks.

Build:
- Bump project version from 0.7.1 to 0.7.2.

</details>