### PR TITLE
fix: 包装类使用

### DIFF
--- a/amrita/plugins/chat/builtin_hook.py
+++ b/amrita/plugins/chat/builtin_hook.py
@@ -394,7 +394,7 @@ async def agent_core(event: BeforeChatEvent) -> None:
     msg_list: SEND_MESSAGES = (
         [
             deepcopy(event.message.train),
-            deepcopy(event.message.memory)[-1],
+            deepcopy(event.message.user_query),
         ]
         if config.llm_config.tools.use_minimal_context
         else event.message.unwrap()

--- a/amrita/plugins/chat/utils/llm_tools/builtin_tools.py
+++ b/amrita/plugins/chat/utils/llm_tools/builtin_tools.py
@@ -23,7 +23,7 @@ async def report(event: BeforeChatEvent, data: dict[str, str], bot: Bot):
     message = data["content"]
     nb_event = typing.cast(MessageEvent, event.get_nonebot_event())
     logger.warning(f"{nb_event.user_id} 被举报了 ：{message}")
-    content = deepcopy(event.get_send_message().memory[-1].content)
+    content = deepcopy(event.get_send_message().get_user_query().content)
     if not isinstance(content, str):
         content = "".join([f"{i.model_dump_json()}\n" for i in content])
     await send_to_admin(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "0.7.3"
+version = "0.7.3.1"
 description = "A powerful AI bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary by Sourcery

更新聊天处理逻辑，以在整个流程中一致地使用 `user_query` 包装器，并提升项目补丁版本号。

Bug 修复：
- 修正 `stop_running` 中的消息上下文选择逻辑，使其使用 `user_query` 包装器而不是最后一条 memory 记录。
- 修复 report 工具，使其从 `user_query` 包装器中提取内容，而不是直接从消息 memory 中提取。

构建：
- 将项目版本从 0.7.3 升级到 0.7.3.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update chat handling to use the user query wrapper consistently and bump project patch version.

Bug Fixes:
- Correct message context selection in stop_running to use the user_query wrapper instead of the last memory entry.
- Fix report tool to extract content from the user_query wrapper rather than directly from message memory.

Build:
- Bump project version from 0.7.3 to 0.7.3.1.

</details>