### PR TITLE
fix: enable switch

### DIFF
--- a/amrita/plugins/chat/check_rule.py
+++ b/amrita/plugins/chat/check_rule.py
@@ -39,23 +39,21 @@ class FakeEvent(Event):
 
 
 async def is_bot_enabled(event: Event) -> bool:
+    gid = getattr(event, "group_id", None)
+    is_in_group = gid is not None
     if not config_manager.config.enable:
         return False
-    elif (
-        hasattr(event, "group_id")
-        and not config_manager.config.function.enable_group_chat
-    ):
+    elif is_in_group and not config_manager.config.function.enable_group_chat:
         return False
-    else:
-        if not config_manager.config.function.enable_private_chat:
-            return False
+    elif not is_in_group and not config_manager.config.function.enable_private_chat:
+        return False
     with contextlib.suppress(Exception):
-        bots = set(nonebot.get_bots().keys())
-        if event.get_user_id() in bots:  # 多实例下防止冲突
+        bots = nonebot.get_bots()
+        if event.get_user_id() in bots:
             return False
-    if (group_id := getattr(event, "group_id", None)) is not None:
+    if gid is not None:
         data = await CachedUserDataRepository().get_group_config(
-            group_id,
+            gid,
         )
         return data.enable
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.1.4"
+version = "1.1.5"
 description = "A powerful AI bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
close #198

## Summary by Sourcery

调整机器人在群聊和私聊中的启用检查逻辑，并提升包版本。

Bug Fixes:
- 在应用启用开关和机器人可用性检查时，正确区分群聊和私聊。

Build:
- 将项目版本从 1.1.4 更新到 1.1.5。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust bot enablement checks for group and private chats and bump the package version.

Bug Fixes:
- Correctly determine group versus private chat when applying enable switches and bot-availability checks.

Build:
- Update project version from 1.1.4 to 1.1.5.

</details>