### PR TITLE
Add breakpoint-driven chat entry, use aiologic locks, bump 1.1.10

### DIFF
--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -274,6 +274,10 @@ class LLM_Config(BaseModel):
         default=["你好，这个问题我暂时无法处理，请稍后再试。"],
         description="触发安全熔断时随机返回的提示消息",
     )
+    agent_strategy: Literal["react", "hybrid-react", "no-action"] = Field(
+        default="react",
+        description="代理策略：react(仅使用ReAct) / hybrid-react(使用混合ReAct) / no-action(跳过Agent运行)",
+    )
 
 
 class Config(BaseModel):

--- a/amrita/plugins/chat/exception.py
+++ b/amrita/plugins/chat/exception.py
@@ -6,14 +6,12 @@ warnings.warn(
     stacklevel=2,
 )
 from amrita_core.hook.exception import (
-    BlockException,
     CancelException,
     MatcherException,
     PassException,
 )
 
 __all__ = [
-    "BlockException",
     "CancelException",
     "MatcherException",
     "PassException",

--- a/amrita/plugins/chat/handlers/chat.py
+++ b/amrita/plugins/chat/handlers/chat.py
@@ -48,7 +48,7 @@ from amrita.plugins.chat.utils.lock import get_group_lock, get_private_lock
 from amrita.plugins.chat.utils.sql import InsightsModel, get_any_id, get_uni_user_id
 from amrita.utils.admin import send_to_admin
 
-from ..runtime import AmritaChatObject
+from ..runtime import CT_BREAKPOINT, AmritaChatObject
 
 command_prefix = get_driver().config.command_start or "/"
 
@@ -338,6 +338,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         exception_ignored=(ProcessException, MatcherException),
     )
     chat.set_callback_func(filter)
+    task_bk = asyncio.create_task(chat.wait_to_suspend(CT_BREAKPOINT))
     try:
         lock = (
             get_group_lock(event.group_id)
@@ -357,12 +358,17 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
                 if lock.locked():
                     debug_log("聊天已被锁定，发送报告")
                     await matcher.finish("聊天任务正在处理中，请稍后再试")
-
-        async with lock:
-            chat.last_call = datetime.now(utc)
+        await asyncio.sleep(0)
+        async with chat.begin():
             chat._pending = False
-            debug_log("获取锁成功，开始获取记忆数据")
-            async with chat.begin():
+            debug_log("正在等待运行到断点...")
+
+            async with lock:
+                debug_log("获取锁成功，开始获取记忆数据")
+                chat.resume()
+                debug_log("继续运行...")
+                await asyncio.wait_for(task_bk, 5)  # 等断点继续
+                await asyncio.sleep(0)
                 await chat  # Wait for workflow to complete
                 chat.memory.memory_json = chat.data
                 await cudr.update_memory_data(chat.memory)

--- a/amrita/plugins/chat/handlers/preset_test.py
+++ b/amrita/plugins/chat/handlers/preset_test.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
-from asyncio import Lock
 
+from aiologic import Lock
 from amrita_core import PresetManager, PresetReport
 from nonebot.adapters.onebot.v11 import Bot, Message, MessageEvent, MessageSegment
 from nonebot.matcher import Matcher

--- a/amrita/plugins/chat/runtime.py
+++ b/amrita/plugins/chat/runtime.py
@@ -1,9 +1,11 @@
 import contextlib
 import time
-from asyncio import CancelledError, Lock
+from asyncio import CancelledError
 from dataclasses import dataclass, field
 from datetime import datetime
+from uuid import uuid4
 
+from aiologic import Lock
 from amrita_core import (
     ChatObject as CoreChatObject,
 )
@@ -11,9 +13,11 @@ from amrita_core import (
     ChatObjectMeta as CoreChatObjectMeta,
 )
 from amrita_core import (
+    SuspendObjectStream,
     ToolResult,
     get_config,
 )
+from amrita_core.chatmanager import chat_manager as core_chat_manager
 from amrita_core.config import AmritaConfig
 from amrita_core.logging import debug_log
 from nonebot import logger
@@ -43,7 +47,7 @@ from .utils.sql import (
 )
 
 LOCK = Lock()
-
+CT_BREAKPOINT = "ChatObject::_run"
 
 @final
 class ChatObjectMeta(CoreChatObjectMeta):
@@ -116,6 +120,36 @@ class AmritaChatObject(CoreChatObject):
         self.config = get_config()
 
     @override
+    @CoreChatObject.monitoring
+    @SuspendObjectStream.suspend
+    async def _entry(self) -> None:
+        """Call chat object to process messages"""
+        if not self._is_running and not self._is_done:
+            self.stream_id = uuid4().hex
+            logger.debug(f"Starting chat processing, stream ID:{self.stream_id}")
+
+            try:
+                self._is_running = True
+                await core_chat_manager.add_chat_object(self)
+                await self._wait_for_continue(CT_BREAKPOINT)
+                await self._run()
+            finally:
+                self._is_running = False
+                self._is_done = True
+                self.end_at = datetime.now(utc)
+                core_chat_manager.running_chat_object_id2map.pop(self.stream_id, None)
+                core_chat_manager.clean_obj(
+                    self.session_id, 1000
+                )  # To avoid memory leaks
+                logger.debug("Chat event processing completed")
+
+        else:
+            raise RuntimeError(
+                f"ChatObject of {self.stream_id} is already running or done"
+            )
+
+    @override
+    @SuspendObjectStream.suspend
     async def _run(self) -> None:
         """运行聊天处理流程
 
@@ -124,7 +158,6 @@ class AmritaChatObject(CoreChatObject):
         """
         debug_log("开始运行聊天处理流程..")
         event = self.event
-        config = self.bot_config
         self.memory = await CachedUserDataRepository().get_memory(*get_any_id(event))
         for mem in self.memory.memory_json.messages:
             if (
@@ -141,16 +174,14 @@ class AmritaChatObject(CoreChatObject):
 
         debug_log(f"添加用户消息到记忆，当前消息总数: {len(data.messages)}")
 
-        self.train["content"] = (
+        self.train.content = (
             "<SCHEMA_EXTENSIONS>\n"
             + "你在纯文本环境工作，不允许使用MarkDown回复，你的工作环境是一个社交软件，我会提供聊天记录，你可以从这里面获取一些关键信息，比如时间与用户身份"
             + "（e.g.: [管理员/群主/自己/群员][YYYY-MM-DD weekday hh:mm:ss AM/PM][昵称（QQ号）]说:<内容>），但是请不要以聊天记录的格式做回复，而是纯文本方式。"
             + "请以你自己的角色身份参与讨论，交流时不同话题尽量不使用相似句式回复，用户与你交谈的信息在用户的消息输入内。<EXTRA>规则仅作为补充，如果与EXTRA规则上文有冲突，请遵循上文规则。"
             + "\n</SCHEMA_EXTENSION>\n"
             + (
-                self.train["content"]
-                .replace("{cookie}", config.cookies.cookie)
-                .replace("{self_id}", str(event.self_id))
+                self.train.content.replace("{self_id}", str(event.self_id))
                 .replace("{user_id}", str(event.user_id))
                 .replace("{user_name}", str(event.sender.nickname))
             )
@@ -163,6 +194,7 @@ class AmritaChatObject(CoreChatObject):
 
         await super()._run()
 
+    @SuspendObjectStream.suspend
     async def _manage_sessions(
         self,
     ):
@@ -214,11 +246,9 @@ class AmritaChatObject(CoreChatObject):
                     CachedUserDataRepository._cached_memory.pop(uni_id, None)
                     self.memory.memory_json = data
                     await CachedUserDataRepository().update_memory_data(self.memory)
-                    if (
-                        (time_now - timestamp)
-                        <= float(config.session.session_control_time * 60 * 2)
-                        and config.session.session_allow_continue
-                    ):
+                    if (time_now - timestamp) <= float(
+                        config.session.session_control_time * 60 * 2
+                    ) and config.session.session_allow_continue:
                         debug_log("发送继续聊天提示")
                         chated = await matcher.send(
                             f'如果想和我继续用之前的上下文聊天，快at我回复✨"继续"✨吧！\n（超过{config.session.session_control_time}分钟没理我我就会被系统抱走存档哦！）'
@@ -253,6 +283,7 @@ class AmritaChatObject(CoreChatObject):
                 data.time = time.time()
                 debug_log("会话上下文管理完成")
 
+    @SuspendObjectStream.suspend
     async def _throw(self, e: BaseException):
         """处理异常：
         - 通知用户出错。

--- a/amrita/plugins/chat/utils/app.py
+++ b/amrita/plugins/chat/utils/app.py
@@ -1,8 +1,8 @@
 # Pydantic Models
-from asyncio import Lock
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 
+from aiologic import Lock
 from amrita_core import MemoryModel as Memory
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict as PydConf
@@ -163,11 +163,10 @@ class CachedUserDataRepository:
         """!此方法没有缓存!"""
         uni_id = self.make_uni_id(any_id, is_group)
         # 因为缓存数据可能更新不及时，并且更新也麻烦，因为它不常访问，sessions归档这里就没有再做缓存了，只是简单校验了离线模型。
-        async with self.make_lock(uni_id):
-            async with UserDataExecutor(uni_id) as exc:
-                sessions = await exc.get_or_load_sessions()
-                data = [MemorySessionsSchema.model_validate(s) for s in sessions]
-            return data
+        async with UserDataExecutor(uni_id) as exc:  # 这里没有缓存的逻辑，所以不带锁。
+            sessions = await exc.get_or_load_sessions()
+            data = [MemorySessionsSchema.model_validate(s) for s in sessions]
+        return data
 
     async def update_group_config(self, data: GroupConfigSchema) -> None:
         uni_id = data.user_id

--- a/amrita/plugins/chat/utils/lock.py
+++ b/amrita/plugins/chat/utils/lock.py
@@ -1,35 +1,36 @@
-import asyncio
 from collections.abc import Hashable
+
+import aiologic
 
 from amrita.cache import WeakValueLRUCache
 
-_group_lock: WeakValueLRUCache[Hashable, asyncio.Lock] = WeakValueLRUCache(
+_group_lock: WeakValueLRUCache[Hashable, aiologic.Lock] = WeakValueLRUCache(
     capacity=1024, loose_mode=True
 )
-_private_lock: WeakValueLRUCache[Hashable, asyncio.Lock] = WeakValueLRUCache(
+_private_lock: WeakValueLRUCache[Hashable, aiologic.Lock] = WeakValueLRUCache(
     capacity=1024, loose_mode=True
 )
-_database_lock: WeakValueLRUCache[Hashable, asyncio.Lock] = WeakValueLRUCache(
+_database_lock: WeakValueLRUCache[Hashable, aiologic.Lock] = WeakValueLRUCache(
     capacity=2048, loose_mode=True
 )
 
 
-def get_group_lock(id: int) -> asyncio.Lock:
+def get_group_lock(id: int) -> aiologic.Lock:
     if (lock := _group_lock.get(id)) is None:
-        lock = asyncio.Lock()
+        lock = aiologic.Lock()
         _group_lock.put(id, lock)
     return lock
 
 
-def get_private_lock(id: int) -> asyncio.Lock:
+def get_private_lock(id: int) -> aiologic.Lock:
     if (lock := _private_lock.get(id)) is None:
-        lock = asyncio.Lock()
+        lock = aiologic.Lock()
         _private_lock.put(id, lock)
     return lock
 
 
-def database_lock(*args: Hashable) -> asyncio.Lock:
+def database_lock(*args: Hashable) -> aiologic.Lock:
     if (lock := _database_lock.get(args)) is None:
-        lock = asyncio.Lock()
+        lock = aiologic.Lock()
         _database_lock.put(args, lock)
     return lock

--- a/amrita/plugins/chat/utils/sql.py
+++ b/amrita/plugins/chat/utils/sql.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import re
 import time
-from asyncio import Lock, Protocol
+from asyncio import Protocol
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
+from aiologic import Lock
 from amrita_core.types import (
     _T,
     CT_MAP,
@@ -380,7 +381,7 @@ class UserDataExecutor:
 
     async def __aenter__(self) -> Self:
         self._entered = True
-        await self._lock.acquire()
+        await self._lock.__aenter__()
         self._transaction = self.session.begin()
         if self._arg_session is None:
             await self.session.__aenter__()
@@ -401,7 +402,7 @@ class UserDataExecutor:
                 await self.session.__aexit__(exc_type, exc_value, traceback)
         finally:
             self._entered = False
-            self._lock.release()
+            await self._lock.__aexit__(exc_type, exc_value, traceback)
 
     async def _get_or_create_any(self, model: type[SqlModel_T], **kwargs) -> SqlModel_T:
         stmt = select(model).where(model.user_id == self.user_id)

--- a/amrita/plugins/manager/checker.py
+++ b/amrita/plugins/manager/checker.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from typing import Any
 from weakref import WeakSet
 
+import aiologic
 from nonebot import get_driver, logger, on_command, on_message, on_notice
 from nonebot.adapters import Bot
 from nonebot.adapters.onebot.v11 import (
@@ -49,7 +50,7 @@ watch_user = defaultdict(
 # 用于存储待处理的usage调用
 _usage_queue: list[tuple[str, int, int]] = []  # list of (self_id, msg_count, api_count)
 _running_task: WeakSet[asyncio.Task] = WeakSet()
-_usage_lock = asyncio.Lock()
+_usage_lock = aiologic.Lock()
 _record_task = None
 
 
@@ -86,7 +87,7 @@ def _start_usage_processor():
 
 class APICalledRepo:
     _repo: defaultdict[str, tuple[int, int]]  # (count, successful_count, cost)
-    _lock_pool: WeakValueLRUCache[str, asyncio.Lock]
+    _lock_pool: WeakValueLRUCache[str, aiologic.Lock]
     _instance = None
 
     def __new__(cls) -> Self:
@@ -117,7 +118,7 @@ class APICalledRepo:
 
     def _lock(self, api: str):
         if (lock := self._lock_pool.get(api)) is None:
-            lock = asyncio.Lock()
+            lock = aiologic.Lock()
             self._lock_pool[api] = lock
         return lock
 

--- a/amrita/plugins/manager/models.py
+++ b/amrita/plugins/manager/models.py
@@ -1,6 +1,6 @@
-import asyncio
 from datetime import datetime, timedelta
 
+import aiologic
 from nonebot_plugin_orm import AsyncSession, Model, get_session
 from pydantic import BaseModel
 from sqlalchemy import (
@@ -20,9 +20,9 @@ from amrita.cache import WeakValueLRUCache
 _lock_pool = WeakValueLRUCache(2048, True)
 
 
-def lock(bid: str) -> asyncio.Lock:
+def lock(bid: str) -> aiologic.Lock:
     if (lock := _lock_pool.get(bid)) is None:
-        lock = asyncio.Lock()
+        lock = aiologic.Lock()
         _lock_pool.put(bid, lock)
     return lock
 

--- a/amrita/plugins/perm/models.py
+++ b/amrita/plugins/perm/models.py
@@ -1,9 +1,9 @@
 from abc import ABC
-from asyncio import Lock
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 
+from aiologic import Lock
 from nonebot_plugin_orm import Model, get_session
 from pydantic import BaseModel as B_Model
 from sqlalchemy import (

--- a/amrita/plugins/webui/service/authlib.py
+++ b/amrita/plugins/webui/service/authlib.py
@@ -5,11 +5,11 @@ import random
 import re
 import secrets
 from abc import ABC
-from asyncio import Lock
 from datetime import datetime, timedelta
 from typing import TypeVar, overload
 
 import bcrypt
+from aiologic import Lock
 from fastapi import HTTPException, Request
 from nonebot import logger
 from pydantic import BaseModel, Field

--- a/amrita/utils/admin.py
+++ b/amrita/utils/admin.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import time
 import typing
-from asyncio import Lock
 from collections import defaultdict
 
 import nonebot
+from aiologic import Lock
 from nonebot import logger
 from nonebot.adapters.onebot.v11 import Bot, MessageSegment
 

--- a/amrita/utils/logging.py
+++ b/amrita/utils/logging.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from asyncio import Lock
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
 import aiofiles
+from aiologic import Lock
 from pydantic import BaseModel, Field
 
 from amrita.config import get_amrita_config

--- a/amrita/utils/utils.py
+++ b/amrita/utils/utils.py
@@ -9,9 +9,9 @@ except metadata.PackageNotFoundError:
     pass
 
 
-
 def get_amrita_version():
     return __version__
+
 
 def get_core_version():
     return __core_version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.1.9.1"
+version = "1.1.10"
 description = "A powerful AI bot framework powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -15,17 +15,18 @@ dependencies = [
     "nonebot-plugin-localstore>=0.7.4",
     "typing-extensions>=4.6.0",
     "uv>=0.8.12",
-    "requests>=2.0",                    # See https://github.com/twindb/backup/pull/465
+    "requests>=2.0", # See https://github.com/twindb/backup/pull/465
     "python-multipart>=0.0.20",
     "aiofiles>=24.1.0",
     "packaging>=25.0",
     "zipp>=3.23.0",
     "pytz>=2025.2",
     "tomlkit>=0.13.3",
-    "nonebot-plugin-orm>=0.8.3",        # See https://github.com/nonebot/plugin-orm/issues/33
+    "nonebot-plugin-orm>=0.8.3", # See https://github.com/nonebot/plugin-orm/issues/33
     "nb-cli==1.6.0",
     "watchfiles>=1.1.1",
-    "amrita-core>=0.8.0, <0.9.0",
+    "amrita-core>=0.8.4, <0.9.0",
+    "aiologic>=0.16.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -230,10 +230,11 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "1.1.9"
+version = "1.1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "aiologic" },
     { name = "amrita-core" },
     { name = "click" },
     { name = "colorama" },
@@ -297,11 +298,12 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", marker = "extra == 'full'", specifier = ">=3.13.2" },
+    { name = "aiologic", specifier = ">=0.16.0" },
     { name = "aiomysql", marker = "extra == 'full'", specifier = ">=0.3.2" },
     { name = "aiopg", marker = "extra == 'full'", specifier = ">=1.4.0" },
     { name = "aiosqlite", marker = "extra == 'full'", specifier = ">=0.21.0" },
     { name = "alembic", marker = "extra == 'full'", specifier = "==1.16.4" },
-    { name = "amrita-core", specifier = ">=0.8.0,<0.9.0" },
+    { name = "amrita-core", specifier = ">=0.8.4,<0.9.0" },
     { name = "async-lru", marker = "extra == 'full'", specifier = ">=2.0.5" },
     { name = "bcrypt", marker = "extra == 'full'", specifier = ">=4.3.0" },
     { name = "click", specifier = ">=8.2.1" },
@@ -354,7 +356,7 @@ dev = [
 
 [[package]]
 name = "amrita-core"
-version = "0.8.2"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -371,9 +373,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/e8/e9f1ffb0ec5d31046b02a0e79dc1bce20e838350bc53c64cb63180b017d3/amrita_core-0.8.2.tar.gz", hash = "sha256:8f89b96f376fbe2ec2a1591d175a048877454b0516954863646ba9dd15c677f0", size = 102356, upload-time = "2026-04-19T14:38:43.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/66/12d645c49c31b6d357ff1d29f75ffd51c3dad1eec7424642f7b2b9d51eb0/amrita_core-0.8.4.tar.gz", hash = "sha256:79750f9168d9ddbc5e19093297881ef1d0b2826e2f78ec12e703ec58956c34f4", size = 107760, upload-time = "2026-04-25T12:19:34.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/7d/cdf4e579589dcc2fcc8e703e9b98635b182be7a1a6e99b11658d4483f400/amrita_core-0.8.2-py3-none-any.whl", hash = "sha256:75080aebc165fedb053963b38036b09aef9f8f3ba252d75c396bbf6369f83bf1", size = 76879, upload-time = "2026-04-19T14:38:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/48/4d/7ab46ac269e344b6bf74cc4c659b65b7860c44510f873f7df93040853218/amrita_core-0.8.4-py3-none-any.whl", hash = "sha256:873a07fc3b68e5aade98f1d8ac7115f32fdc1f836a20b4925547b387bef0f9c7", size = 80248, upload-time = "2026-04-25T12:19:33.228Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

引入基于断点的聊天执行流程和可挂起的入口点，采用 aiologic 进行异步锁管理，并更新核心依赖和配置。

New Features:
- 新增一个可监控、可挂起的聊天入口点，并支持断点控制，以精确控制聊天处理何时开始。
- 引入可配置的 LLM agent 策略选项，可在 ReAct、混合 ReAct 或无动作（no-action）行为之间进行选择。

Bug Fixes:
- 确保 SQL 用户数据执行器的锁正确作为异步上下文管理器使用，避免错误的获取/释放模式。
- 在读取未缓存的用户会话时避免不必要的加锁，以减少竞争和潜在死锁。

Enhancements:
- 优化聊天会话处理，将锁管理与基于断点的恢复机制协调起来，避免同时运行多个聊天实例。
- 调整聊天 prompt 构建方式，改为使用属性式访问并简化占位符替换逻辑，移除未使用的 cookie 注入。
- 为额外的聊天对象生命周期方法添加流挂起相关的装饰器，以融入新的流控制模型。
- 简化会话续接的超时逻辑，提升可读性，同时保持现有行为不变。
- 整理工具函数以及与版本辅助函数和配置注释相关的小幅格式调整。

Build:
- 将项目版本提升至 1.1.10，并将 amrita-core 依赖范围更新为 >=0.8.4,<0.9.0。
- 新增 aiologic 作为运行时依赖，用于提供高级异步锁原语。

Chores:
- 在聊天和管理模块中用基于 aiologic 的锁替换 asyncio.Lock，并使用共享的 WeakValueLRUCache 池以实现更精细的异步控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce breakpoint-based chat execution flow with suspendable entry, adopt aiologic for asynchronous locking, and update core dependencies and configuration.

New Features:
- Add a monitored, suspendable chat entrypoint with breakpoint support to control when chat processing starts.
- Introduce a configurable LLM agent strategy option to select between ReAct, hybrid ReAct, or no-action behaviors.

Bug Fixes:
- Ensure SQL user data executor locks are correctly used as async context managers to avoid improper acquire/release patterns.
- Prevent unnecessary locking when reading uncached user sessions to reduce contention and potential deadlocks.

Enhancements:
- Refine chat session handling to coordinate locking with a breakpoint-driven resume mechanism and avoid running multiple chat instances concurrently.
- Adjust chat prompt construction to use attribute-style access and simplify placeholder substitution, removing unused cookie injection.
- Annotate additional chat object lifecycle methods with stream suspension decorators to integrate with the new streaming control model.
- Simplify session continuation timeout logic for readability while preserving existing behavior.
- Tidy utility functions and minor formatting for version helpers and configuration comments.

Build:
- Bump project version to 1.1.10 and update amrita-core dependency range to >=0.8.4,<0.9.0.
- Add aiologic as a new runtime dependency for advanced asynchronous locking primitives.

Chores:
- Replace asyncio.Lock usage across chat and manager modules with aiologic-based locks backed by shared WeakValueLRUCache pools for finer-grained async control.

</details>